### PR TITLE
Cleanup shortcut display after edit

### DIFF
--- a/ShortcutCustomizeUI.js
+++ b/ShortcutCustomizeUI.js
@@ -287,7 +287,7 @@ var ShortcutCustomizeUI = {
     global: {
       Comma:  [','],
       Period: ['.'],
-      Space:  ['Space'],
+      Space:  [' '],
       Up:     ['↑'],
       Down:   ['↓'],
       Left:   ['←', '<=', '<-'],

--- a/ShortcutCustomizeUI.js
+++ b/ShortcutCustomizeUI.js
@@ -27,7 +27,7 @@ var ShortcutCustomizeUI = {
     list.classList.add('shortcuts');
     const items    = [];
     for (let command of commands) {
-      command.updateKey = command.shortcut.replace(/(Alt|Control|Ctrl|Command|Meta|Shift)\+/gi, '').trim();
+      command.currentUnmodifedHotkey = command.shortcut.replace(/(Alt|Control|Ctrl|Command|Meta|Shift)\+/gi, '').trim();
       const update = () => {
         const key = this.normalizeKey(keyField.value);
         if (!key)
@@ -42,7 +42,7 @@ var ShortcutCustomizeUI = {
         if (shiftLabel.checkbox.checked)
           shortcut.push('Shift');
         shortcut.push(key);
-        command.updateKey = key;
+        command.currentUnmodifedHotkey = key;
         const fullShortcut = shortcut.join('+');
         try {
           browser.commands.update({
@@ -91,8 +91,8 @@ var ShortcutCustomizeUI = {
         })
       };
 
-      const clean = () => {
-        keyField.value = this.getLocalizedKey(command.updateKey) || command.updateKey;
+      const cleanKeyField = () => {
+        keyField.value = this.getLocalizedKey(command.currentUnmodifedHotkey) || command.currentUnmodifedHotkey;
       }
 
       const item = document.createElement('li');
@@ -126,7 +126,7 @@ var ShortcutCustomizeUI = {
       keyField.setAttribute('type', 'text');
       keyField.setAttribute('size', 8);
       keyField.addEventListener('input', update);
-      keyField.addEventListener('blur', clean);
+      keyField.addEventListener('blur', cleanKeyField);
       if (!this.available)
         keyField.setAttribute('disabled', true);
 

--- a/ShortcutCustomizeUI.js
+++ b/ShortcutCustomizeUI.js
@@ -27,6 +27,7 @@ var ShortcutCustomizeUI = {
     list.classList.add('shortcuts');
     const items    = [];
     for (let command of commands) {
+      command.updateKey = command.shortcut.replace(/(Alt|Control|Ctrl|Command|Meta|Shift)\+/gi, '').trim();
       const update = () => {
         const key = this.normalizeKey(keyField.value);
         if (!key)
@@ -41,6 +42,7 @@ var ShortcutCustomizeUI = {
         if (shiftLabel.checkbox.checked)
           shortcut.push('Shift');
         shortcut.push(key);
+        command.updateKey = key;
         try {
           browser.commands.update({
             name:     command.name,
@@ -79,6 +81,10 @@ var ShortcutCustomizeUI = {
         keyField.value = this.getLocalizedKey(key) || key;
       };
 
+      const clean = () => {
+        keyField.value = this.getLocalizedKey(command.updateKey) || command.updateKey;
+      }
+
       const item = document.createElement('li');
       item.classList.add(this.commonClass);
       item.classList.add('shortcut');
@@ -110,6 +116,7 @@ var ShortcutCustomizeUI = {
       keyField.setAttribute('type', 'text');
       keyField.setAttribute('size', 8);
       keyField.addEventListener('input', update);
+      keyField.addEventListener('blur', clean);
       if (!this.available)
         keyField.setAttribute('disabled', true);
 
@@ -270,7 +277,7 @@ var ShortcutCustomizeUI = {
     global: {
       Comma:  [','],
       Period: ['.'],
-      Space:  [' '],
+      Space:  ['Space'],
       Up:     ['↑'],
       Down:   ['↓'],
       Left:   ['←', '<=', '<-'],


### PR DESCRIPTION
This adds an `onBlur` function to the input boxs such that after they've been edited and deselected, the content is updated to what the hotkey has actually been updated to.

e.g. if `fish` is entered into an input box, after it has lost focus it will be updated to `F`

It is a little hacky in that it's adding an extra property to the `command` object, so if you can think of a better way of doing it i'm all ears!