### PR TITLE
Fix normalization of the 'right'  key

### DIFF
--- a/ShortcutCustomizeUI.js
+++ b/ShortcutCustomizeUI.js
@@ -291,7 +291,7 @@ const ShortcutCustomizeUI = {
       case 'left':
         return 'Left';
       case 'right':
-        return 'right';
+        return 'Right';
       case 'next':
       case 'medianexttrack':
       case 'mediatracknext':


### PR DESCRIPTION
This is a fix for issue described in https://github.com/lidel/google-music-hotkeys/issues/13:

> "Left" seems to work fine, but "Right" gets translated to "right" and then shows up as an error [..]
> 
> 
> ![Screen Shot 2019-03-20 at 4 36 21 PM](https://user-images.githubusercontent.com/2769203/54725996-56e5f280-4b2e-11e9-8986-670a8a3b2917.png)
